### PR TITLE
Artemis: feat: Improve TaskType.fromString performance using cache

### DIFF
--- a/src/main/java/com/llmproxy/model/TaskType.java
+++ b/src/main/java/com/llmproxy/model/TaskType.java
@@ -1,5 +1,8 @@
 package com.llmproxy.model;
 
+import java.util.Map;
+import java.util.HashMap;
+
 public enum TaskType {
     TEXT_GENERATION("text_generation"),
     SUMMARIZATION("summarization"),
@@ -8,6 +11,15 @@ public enum TaskType {
     OTHER("other");
     
     private final String value;
+    
+    // Cache for fromString method to improve performance
+    private static final Map<String, TaskType> STRING_TO_ENUM_MAP = new HashMap<>();
+
+    static {
+        for (TaskType type : values()) {
+            STRING_TO_ENUM_MAP.put(type.value.toLowerCase(), type);
+        }
+    }
     
     TaskType(String value) {
         this.value = value;
@@ -18,12 +30,11 @@ public enum TaskType {
     }
     
     public static TaskType fromString(String text) {
-        for (TaskType type : TaskType.values()) {
-            if (type.value.equalsIgnoreCase(text)) {
-                return type;
-            }
+        if (text == null) {
+            return OTHER; // Or throw IllegalArgumentException, depending on desired behavior
         }
-        return OTHER;
+        TaskType type = STRING_TO_ENUM_MAP.get(text.toLowerCase());
+        return type != null ? type : OTHER;
     }
     
     @Override


### PR DESCRIPTION
This change improves the performance of the `TaskType.fromString` method by replacing the linear scan through enum values with a static cache (HashMap). The cache is populated once on class loading, allowing subsequent lookups to be O(1) on average, significantly faster than the previous O(n) approach for frequent calls or larger enums.

Additionally, a null check is added to `fromString` to return `OTHER` for null input, improving robustness.



<details>
<summary>Detailed Score Information</summary>

### Score Details

This section contains detailed information about the performance scores for top 5 scored suggestions.

## Top Performing Changes

### 1. src/main/java/com/llmproxy/model/TaskType.java:1-33 - Mean Improvement: 0.61, Mean Original Score: 4.87

- 🟢 **Performance** (Change: +1.75): The changes significantly improve performance by implementing a lookup map for TaskType values. The original implementation used a linear search through all enum values for each lookup, which has O(n) complexity. The new implementation creates a static HashMap that maps string values to enum constants, allowing O(1) lookups. This is especially valuable if 'fromString' is called frequently in performance-critical code paths. The code also adds a null check to prevent potential NullPointerExceptions.

- 🟢 **Quality** (Score: 4.87; Change: +0.13): The code quality is improved with several thoughtful enhancements. The addition of imports is properly organized. The implementation of a static map with appropriate comments explains the purpose of the cache. The null check in fromString adds robustness. The code becomes more maintainable as the lookup logic is simplified and optimized. The only minor issue is that the map is populated with lowercase values while the original comparison was case-insensitive, which maintains the same behavior but makes the implementation intention more clear.

- 🟢 **Value** (Change: +1.75): The changes significantly improve the value of the code by optimizing the TaskType.fromString method with a precomputed lookup map, which makes lookups O(1) instead of O(n) through an enum list. This is particularly valuable if this conversion is called frequently or if the enum grows. It also adds null handling for robustness. These provide practical performance and maintainability gains while maintaining the class's existing behavior.


</details>
